### PR TITLE
Rewrite EventPayload

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ name = "pypi"
 
 aioamqp = "*"
 "e1839a8" = {path = ".", editable = true}
+jsonschema = "*"
 pydantic = "*"
 pyyaml = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -181,7 +181,7 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,20 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "750d608884324e73f9a30e0d383c4fa521e72685a039dd4e08d419250c11d36c"
-        },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "3.6.2",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "17.4.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64",
-            "python_full_version": "3.6.2",
-            "python_version": "3.6",
-            "sys_platform": "darwin"
+            "sha256": "94b960b71efaf34b97ecfc27686b3f9172af6690e6a8440de035d750dcf1409c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,141 +21,154 @@
                 "sha256:2fa0c7b1199f196f7bc04d3a486fea1a0ed44387bf0d2241a823116a6dfdadff",
                 "sha256:c618af6d005942a2a8711f7548348f9028fac2673f0dc2d192310cef83486204"
             ],
+            "index": "pypi",
             "version": "==0.10.0"
         },
         "e1839a8": {
             "editable": true,
             "path": "."
         },
+        "jsonschema": {
+            "hashes": [
+                "sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08",
+                "sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02"
+            ],
+            "index": "pypi",
+            "version": "==2.6.0"
+        },
         "pydantic": {
             "hashes": [
-                "sha256:fe9b99dbc8b5c33c6002b711e91dd01688822cb942bd32314d918a62fca529b4",
-                "sha256:464826dbfdb7599d31d55bcb38b94a51186d4b8368e20c7082b05d17924435ba"
+                "sha256:3976cf6c1022a622136ccc5f3fa3a8bf174bd4539c8b085d2b66fc2272f60110",
+                "sha256:85639faeced3fb2ba9d149efbdf0a4c62630ac7b268af966c3d2dfc98235e86f"
             ],
-            "version": "==0.7.1"
+            "index": "pypi",
+            "version": "==0.8"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
+                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
                 "sha256:16b20e970597e051997d90dc2cddc713a2876c47e3d92d59ee198700c5427736",
-                "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269",
+                "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
+                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
+                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
+                "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
+                "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7",
+                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
+                "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
+                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
                 "sha256:bc6bced57f826ca7cb5125a10b23fd0f2fff3b7c4701d64c439a300ce665fff8",
                 "sha256:c01b880ec30b5a6e6aa67b09a2fe3fb30473008c85cd6a67359a1b15ed6d83a4",
-                "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
-                "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
-                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
-                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
-                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
                 "sha256:ca233c64c6e40eaa6c66ef97058cdc80e8d0157a443655baa1b2966e812807ca",
-                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
-                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
-                "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7"
+                "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269"
             ],
+            "index": "pypi",
             "version": "==3.12"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:db5cfc9af6e0b60cd07c19478fb54021fc20d2d189882fbcbc94fc69a8aecc58",
-                "sha256:f0a0e386dbca9f93ea9f3ea6f32b37a24720502b7baa9cb17c3976a680d43a06"
+                "sha256:35cfae47aac19c7b407b7095410e895e836f2285ccf1220336afba744cc4c5f2",
+                "sha256:38186e481b65877fd8b1f9acc33e922109e983eb7b6e487bd4c71002134ad331"
             ],
-            "version": "==1.6.1"
+            "version": "==1.6.3"
         },
         "attrs": {
             "hashes": [
-                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450",
-                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9"
+                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
+                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
             ],
             "version": "==17.4.0"
         },
         "coverage": {
             "hashes": [
-                "sha256:7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc",
-                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
-                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
-                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
-                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
-                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
-                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
-                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
-                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
-                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
-                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
-                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
-                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
-                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
-                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
-                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
-                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
-                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
-                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
-                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
-                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
-                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
-                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
-                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
-                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
-                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
-                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
-                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
-                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
-                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
+                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
                 "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
-                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
                 "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
+                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
+                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
+                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
+                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
+                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
+                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
+                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
+                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
+                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
+                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
+                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
+                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
+                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
+                "sha256:7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc",
+                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
+                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
+                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
+                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
+                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
+                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
+                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
+                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
+                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
+                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
                 "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
                 "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
             "version": "==4.5.1"
         },
         "flake8": {
             "hashes": [
-                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37",
-                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0"
+                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
+                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37"
             ],
+            "index": "pypi",
             "version": "==3.5.0"
         },
         "isort": {
             "hashes": [
-                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497",
                 "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
-                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8"
+                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
+                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
+            "index": "pypi",
             "version": "==4.3.4"
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
-                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
-                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
-                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
-                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
-                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
-                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
-                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
-                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
-                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
-                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
-                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
-                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
-                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
-                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
-                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
-                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
-                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b",
-                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
-                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
-                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
-                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
-                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
-                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
                 "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
-                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
-                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
+                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
+                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
                 "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
-                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a"
+                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
+                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
+                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
+                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
+                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
+                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
+                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
+                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
+                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
+                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
+                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
+                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
+                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
+                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
+                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
+                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
+                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
+                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
+                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
+                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
+                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
+                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
+                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
+                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
+                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
             ],
             "version": "==1.3.1"
         },
@@ -179,23 +179,35 @@
             ],
             "version": "==0.6.1"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:0dd8f72eeab0d2c3bd489025bb2f6a1b8342f9b198f6fc37b52d15cfa4531fea",
+                "sha256:11a625025954c20145b37ff6309cd54e39ca94f72f6bb9576d1195db6fa2442e",
+                "sha256:c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44"
+            ],
+            "version": "==4.1.0"
+        },
         "pluggy": {
             "hashes": [
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
                 "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },
         "py": {
             "hashes": [
-                "sha256:8cca5c229d225f8c1e3085be4fcf306090b00850fefad892f9d96c7b6e2f310f",
-                "sha256:ca18943e28235417756316bfada6cd96b23ce60dd532642690dcfdaba988a76d"
+                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
+                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
             ],
-            "version": "==1.5.2"
+            "version": "==1.5.3"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9",
-                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766"
+                "sha256:1ec08a51c901dfe44921576ed6e4c1f5b7ecbad403f871397feedb5eb8e4fa14",
+                "sha256:5ff2fbcbab997895ba9ead77e1b38b3ebc2e5c3b8a6194ef918666e4c790a00e",
+                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
+                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
             ],
             "version": "==2.3.1"
         },
@@ -208,29 +220,32 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:156839bedaa798febee72893beef00c650c2e7abafb5586fc7a6a56be7f80412",
-                "sha256:4fe3b99da7e789545327b75548cee6b511e4faa98afe268130fea1af4b5ec022"
+                "sha256:0b7e6b5d9f1d4e0b554b5d948f14ed7969e8cdf9a0120853e6e5af60813b18ab",
+                "sha256:34738a82ab33cbd3bb6cd4cef823dbcabdd2b6b48a4e3a3054a2bbbf0c712be9"
             ],
-            "version": "==1.8.2"
+            "index": "pypi",
+            "version": "==1.8.4"
         },
         "pytest": {
             "hashes": [
-                "sha256:062027955bccbc04d2fcd5d79690947e018ba31abe4c90b2c6721abec734261b",
-                "sha256:117bad36c1a787e1a8a659df35de53ba05f9f3398fb9e4ac17e80ad5903eb8c5"
+                "sha256:54713b26c97538db6ff0703a12b19aeaeb60b5e599de542e7fca0ec83b9038e8",
+                "sha256:829230122facf05a5f81a6d4dfe6454a04978ea3746853b2b84567ecf8e5c526"
             ],
-            "version": "==3.4.2"
+            "index": "pypi",
+            "version": "==3.5.1"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec",
-                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d"
+                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
+                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
             ],
+            "index": "pypi",
             "version": "==2.5.1"
         },
         "six": {
             "hashes": [
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
         },

--- a/README.md
+++ b/README.md
@@ -55,23 +55,68 @@ Events have to implement a specific contract that defines the structure and
 value types within the structure of the event. Pydantic is used to parse and
 validate events.
 
+For validation, a content schema set and context schema have to be defined using `twyla.service.message.get_schemata`. These schemata have to conform to [JSONSchema](json-schema.org).
+
+    import twyla.service.message as message
+
+    an_event_content_schema =
+    '''
+        {
+            "$schema": "http://json-schema.org/draft-06/schema#",
+            "title": "Content",
+            "description": "Some content",
+            "type": "object",
+            "properties": {
+                "emission": {
+                    "description": "Some emission",
+                    "type": "string"
+                }
+            }
+        }
+    '''
+
+    content_schema_set = {
+        'an-event': an_event_content_schema
+    }
+
+
+    context_schema =
+    '''
+        {
+            "$schema": "http://json-schema.org/draft-06/schema#",
+            "title": "Context",
+            "description": "Some context",
+            "type": "object",
+            "properties": {
+                "tenant": {
+                    "description": "Some tenant",
+                    "type": "string"
+                },
+                "channel-id": {
+                    "description": "Some channel ID",
+                    "type": "integer"
+                }
+            }
+        }
+    '''
+
+    message.set_schemata(content_schema_set, context_schema)
+
 The event can either implement one of the predefined contracts in this library
 or an automatically discovered contract that gets exposed by the services that
 listen to a particular event.
-
-> TODO: currently only the `Event` and `EventPayload` classes are implemented.
-> The content of the events is just a stub
 
     import twyla.service.events as events
     import twyla.service.message as message
     import twyla.service.test.helpers as helpers
 
     payload = message.EventPayload(
-        message_type='integration',
-        tenant='test-tenant',
-        bot_slug='test-slug',
-        channel='test-channel',
-        channel_user_id='test-user-id'
+        event_name='integration',
+        content={'emission': 'Hello, there'},
+        context={
+            'tenant': 'test-tenant',
+            'channel-id': 1
+        }
     )
 
     helpers.aio_run(events.emit('test-event', payload))

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 The Twyla Service library provides primitives to build micro services that just
 work within the Twyla platform.
 
+## Installation
+
+- Clone this repository to your machine.
+- `cd` to the directory and run `pipenv install --dev`.
+- Make sure that all tests pass: `pytest`.
+
 ## RPC (not yet implemented)
 
 Remote procedure calls are used for synchronous communication between services

--- a/twyla/service/examples/producer.py
+++ b/twyla/service/examples/producer.py
@@ -6,23 +6,55 @@ from uuid import uuid4
 import twyla.service.events as events
 import twyla.service.message as message
 
+an_event_content_schema = '''
+    {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "title": "Content",
+        "description": "Some content",
+        "type": "object",
+        "properties": {
+            "emission": {
+                "description": "Some emission",
+                "type": "string"
+            }
+        }
+    }
+'''
+
+content_schema_set = {
+    'an-event': an_event_content_schema
+}
+
+context_schema = '''
+    {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "title": "Context",
+        "description": "Some context",
+        "type": "object",
+        "properties": {
+            "tenant": {
+                "description": "Some tenant",
+                "type": "string"
+            },
+            "channel-id": {
+                "description": "Some channel ID",
+                "type": "integer"
+            }
+        }
+    }
+'''
+
+message.set_schemata(content_schema_set, context_schema)
 
 async def ticker(interval):
     while True:
         event_payload = message.EventPayload(
-            event_name='test-event',
+            event_name='integration',
+            content={'emission': 'Hello, there'},
             context={
-                'channel': 'test-channel',
-                'channel_user': {
-                    'name': 'test-user',
-                    'id': 24
-                }
-            },
-            content={
-                'condition': 'test-condition',
-                'extra_info': []
-            },
-            meta=message.Meta(uuid=uuid4(), timestamp=datetime.now())
+                'tenant': 'test-tenant',
+                'channel-id': 1
+            }
         )
         await asyncio.sleep(interval)
         await events.emit('my-events', event_payload.to_json())

--- a/twyla/service/examples/producer.py
+++ b/twyla/service/examples/producer.py
@@ -10,11 +10,17 @@ import twyla.service.message as message
 async def ticker(interval):
     while True:
         event_payload = message.EventPayload(
-            message_type='integration',
-            tenant='test-tenant',
-            bot_slug='test-slug',
-            channel='test-channel',
-            channel_user_id='test-user-id',
+            event_name='control',
+            context=message.Context(
+                tenant='test-tenant',
+                bot_slug='test-slug',
+                channel='test-channel',
+                channel_user_id='test-user-id'
+            ),
+            content={
+                'condition': 'test-condition',
+                'extra_info': []
+            },
             meta=message.Meta(uuid=uuid4(), timestamp=datetime.now())
         )
         await asyncio.sleep(interval)

--- a/twyla/service/examples/producer.py
+++ b/twyla/service/examples/producer.py
@@ -10,13 +10,14 @@ import twyla.service.message as message
 async def ticker(interval):
     while True:
         event_payload = message.EventPayload(
-            event_name='control',
-            context=message.Context(
-                tenant='test-tenant',
-                bot_slug='test-slug',
-                channel='test-channel',
-                channel_user_id='test-user-id'
-            ),
+            event_name='test-event',
+            context={
+                'channel': 'test-channel',
+                'channel_user': {
+                    'name': 'test-user',
+                    'id': 24
+                }
+            },
             content={
                 'condition': 'test-condition',
                 'extra_info': []

--- a/twyla/service/message.py
+++ b/twyla/service/message.py
@@ -25,8 +25,7 @@ class Event:
         """
 
         try:
-            payload = EventPayload.parse_raw(self.body)
-            payload = payload.validate()
+            payload = EventPayload.from_json(self.body)
         except ValidationError:
             await self.drop()
             raise
@@ -95,6 +94,12 @@ class EventPayload(BaseModel):
         jsonschema.validate(self.content, content_schema)
         jsonschema.validate(self.context, context_schema)
         return self
+
+    @classmethod
+    def from_json(cls, jayson):
+        payload = cls.parse_raw(jayson)
+        payload = payload.validate()
+        return payload
 
     def to_json(self):
         return jsontool.dumps(self.dict())

--- a/twyla/service/test/common.py
+++ b/twyla/service/test/common.py
@@ -1,39 +1,38 @@
-_content_schema = '''
-{
-    "$schema": "http://json-schema.org/draft-06/schema#",
-    "title": "Request",
-    "description": "A test request",
-    "type": "object",
-    "properties": {
-        "name": { "type": "string" },
-        "text": { "type": "string" }
+import json
+
+
+_content_schema = json.dumps({
+    '$schema': 'http://json-schema.org/draft-06/schema#',
+    'title': 'Request',
+    'description': 'A test request',
+    'type': 'object',
+    'properties': {
+        'name': {'type': 'string'},
+        'text': {'type': 'string'}
     }
-}
-'''
+})
 
 _content_schema_set = {
     'an-event': _content_schema,
     'another-event': 'another-event-content-schema'
 }
 
-_context_schema = '''
-{
-    "$schema": "http://json-schema.org/draft-06/schema#",
-    "title": "ShopContext",
-    "description": "A test context",
-    "type": "object",
-    "properties": {
-        "channel": { "type": "string" },
-        "channel_user": { 
-            "type": "object",
-            "properties": {
-                "name": { "type": "string" },
-                "id": { "type": "number" }
+_context_schema = json.dumps({
+    '$schema': 'http://json-schema.org/draft-06/schema#',
+    'title': 'ShopContext',
+    'description': 'A test context',
+    'type': 'object',
+    'properties': {
+        'channel': {'type': 'string'},
+        'channel_user': {
+            'type': 'object',
+            'properties': {
+                'name': {'type': 'string'},
+                'id': {'type': 'number'}
             }
         }
     }
-}
-'''
+})
 
 
 def schemata_fixtures():

--- a/twyla/service/test/common.py
+++ b/twyla/service/test/common.py
@@ -1,0 +1,40 @@
+_content_schema = '''
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Request",
+    "description": "A test request",
+    "type": "object",
+    "properties": {
+        "name": { "type": "string" },
+        "text": { "type": "string" }
+    }
+}
+'''
+
+_content_schema_set = {
+    'an-event': _content_schema,
+    'another-event': 'another-event-content-schema'
+}
+
+_context_schema = '''
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "ShopContext",
+    "description": "A test context",
+    "type": "object",
+    "properties": {
+        "channel": { "type": "string" },
+        "channel_user": { 
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "id": { "type": "number" }
+            }
+        }
+    }
+}
+'''
+
+
+def schemata_fixtures():
+    return _content_schema_set, _context_schema

--- a/twyla/service/test/integration/test_event_bus.py
+++ b/twyla/service/test/integration/test_event_bus.py
@@ -8,7 +8,7 @@ import unittest.mock as mock
 import twyla.service.events as events
 import twyla.service.queues as queues
 import twyla.service.test.helpers as helpers
-from twyla.service.message import EventPayload, Context
+from twyla.service.message import EventPayload
 
 
 class TestQueues(unittest.TestCase):
@@ -41,12 +41,12 @@ class TestQueues(unittest.TestCase):
                 'request_type': 'test-request',
                 'queue_response': False
             },
-            context=Context(**{
+            context={
                 'tenant': 'test-tenant',
                 'bot_slug': 'test-slug',
                 'channel': 'test-channel',
                 'channel_user_id': 'test-user-id',
-            })
+            }
         )
 
         event_payload2 = {

--- a/twyla/service/test/integration/test_event_bus.py
+++ b/twyla/service/test/integration/test_event_bus.py
@@ -8,13 +8,14 @@ import unittest.mock as mock
 import twyla.service.events as events
 import twyla.service.queues as queues
 import twyla.service.test.helpers as helpers
-from twyla.service.message import EventPayload
+import twyla.service.test.common as common
+from twyla.service.message import set_schemata, EventPayload
 
 
 class TestQueues(unittest.TestCase):
     def setUp(self):
         self.event_name = 'test-event'
-
+        set_schemata(*common.schemata_fixtures())
         os.environ['TWYLA_RABBITMQ_HOST'] = 'localhost'
         os.environ['TWYLA_RABBITMQ_PORT'] = '5672'
         os.environ['TWYLA_RABBITMQ_USER'] = 'guest'
@@ -35,32 +36,32 @@ class TestQueues(unittest.TestCase):
     def test_emit_listen_roundtrip(self):
         received = []
         event_payload = EventPayload(
-            event_name='integration-request',
+            event_name='an-event',
             content={
-                'integration_type': 'test-integration',
-                'request_type': 'test-request',
-                'queue_response': False
+                'name': 'test-name-content',
+                'text': 'test-text-content',
             },
             context={
-                'tenant': 'test-tenant',
-                'bot_slug': 'test-slug',
                 'channel': 'test-channel',
-                'channel_user_id': 'test-user-id',
+                'channel_user': {
+                    'name': 'test-name',
+                    'id': 24
+                }
             }
         )
 
         event_payload2 = {
-            'event_name': 'integration-request',
+            'event_name': 'an-event',
             'content': {
-                'integration_type': 'test-integration',
-                'request_type': 'test-request',
-                'queue_response': False
+                'name': 'test-name-content',
+                'text': 'test-text-content',
             },
             'context': {
-                'tenant': 'test-tenant',
-                'bot_slug': 'test-slug',
                 'channel': 'test-channel',
-                'channel_user_id': 'test-user-id'
+                'channel_user': {
+                    'name': 'test-name',
+                    'id': 24
+                }
             }
         }
 

--- a/twyla/service/test/unit/test_message.py
+++ b/twyla/service/test/unit/test_message.py
@@ -43,21 +43,14 @@ class PayloadTest(unittest.TestCase):
         message._CONTENT_SCHEMA_SET = None
         message._CONTEXT_SCHEMA = None
 
-    def test_schemata_are_empty_when_not_yet_set(self):
-        content_schema_set, context_schema = message.get_schemata()
-        assert content_schema_set is None
-        assert context_schema is None
-
     def test_validation_with_no_schemata_set(self):
-        payload = message.EventPayload.parse_raw(self.test_body)
         with pytest.raises(Exception):
-            payload.validate()
+            payload = message.EventPayload.from_json(self.test_body)
 
     def test_validation_with_only_content(self):
         message.set_schemata(self.content_schema_set, None)
-        payload = message.EventPayload.parse_raw(self.test_body)
         with pytest.raises(Exception):
-            payload.validate()
+            payload = message.EventPayload.from_json(self.test_body)
 
     def test_set_schemata_with_incorrect_content_schemata_set(self):
         with pytest.raises(AssertionError):
@@ -69,10 +62,9 @@ class PayloadTest(unittest.TestCase):
         assert content_schema_set == self.content_schema_set
         assert context_schema == self.context_schema
 
-    def test_payload_parsing(self):
+    def test_payload_from_json(self):
         message.set_schemata(self.content_schema_set, self.context_schema)
-        payload = message.EventPayload.parse_raw(self.test_body)
-        payload = payload.validate()
+        payload = message.EventPayload.from_json(self.test_body)
 
         assert isinstance(payload.meta, message.Meta)
         assert isinstance(payload.content, dict)
@@ -87,11 +79,10 @@ class PayloadTest(unittest.TestCase):
 
     def test_payload_serialization_roundtrip(self):
         message.set_schemata(self.content_schema_set, self.context_schema)
-        payload = message.EventPayload.parse_raw(self.test_body)
-        payload = payload.validate()
+        payload = message.EventPayload.from_json(self.test_body)
         raw_json = payload.to_json()
 
-        new_payload = message.EventPayload.parse_raw(raw_json)
+        new_payload = message.EventPayload.from_json(raw_json)
 
         assert payload.meta.timestamp == new_payload.meta.timestamp
         assert payload.meta.session_id == new_payload.meta.session_id

--- a/twyla/service/test/unit/test_message.py
+++ b/twyla/service/test/unit/test_message.py
@@ -10,22 +10,55 @@ import twyla.service.test.helpers as helpers
 
 class PayloadTest(unittest.TestCase):
     def setUp(self):
-        self.test_body = '''
+        self.content_schema = '''
         {
-            "event_name": "integration-request",
-            "content": {
-                "integration_type": "test-integration",
-                "request_type": "test-request",
-                "queue_response": "False"
-            },
-            "context": {
-                "tenant": "test-tenant",
-                "bot_slug": "slow-slug",
-                "channel": "fbmessenger",
-                "channel_user_id": "some-user-id"
+            "$schema": "http://json-schema.org/draft-06/schema#",
+            "title": "Request",
+            "description": "A test request",
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "text": { "type": "string" }
             }
         }
         '''
+
+        self.context_schema = '''
+        {
+            "$schema": "http://json-schema.org/draft-06/schema#",
+            "title": "ShopContext",
+            "description": "A test context",
+            "type": "object",
+            "properties": {
+                "channel": { "type": "string" },
+                "channel_user": { 
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "id": { "type": "number" }
+                    }
+                }
+            }
+        }
+        '''
+
+        self.test_body = '''
+        {
+            "event_name": "Request",
+            "content": {
+                "name": "test-name",
+                "text": "test-text"
+            },
+            "context": {
+                "channel": "test-channel",
+                "channel_user": {
+                    "name": "test-user",
+                    "id": 24
+                }
+            }
+        }
+        '''
+
         self.invalid_test_body = '''
         {
             "message_type": "integration-request",
@@ -38,17 +71,22 @@ class PayloadTest(unittest.TestCase):
 
     def test_payload_parsing(self):
         payload = message.EventPayload.parse_raw(self.test_body)
+        payload = payload.validate(self.content_schema, self.context_schema)
 
         assert isinstance(payload.meta, message.Meta)
-        assert isinstance(payload.context, message.Context)
-        assert payload.event_name == 'integration-request'
-        assert payload.context.tenant == 'test-tenant'
-        assert payload.context.bot_slug == 'slow-slug'
-        assert payload.context.channel == 'fbmessenger'
-        assert payload.context.channel_user_id == 'some-user-id'
+        assert isinstance(payload.content, dict)
+        assert isinstance(payload.context, dict)
+
+        assert payload.event_name == 'Request'
+        assert payload.content['name'] == 'test-name'
+        assert payload.content['text'] == 'test-text'
+        assert payload.context['channel'] == 'test-channel'
+        assert payload.context['channel_user']['name'] == 'test-user'
+        assert payload.context['channel_user']['id'] == 24
 
     def test_payload_serialization_roundtrip(self):
         payload = message.EventPayload.parse_raw(self.test_body)
+        payload = payload.validate(self.content_schema, self.context_schema)
         raw_json = payload.to_json()
 
         new_payload = message.EventPayload.parse_raw(raw_json)
@@ -56,9 +94,11 @@ class PayloadTest(unittest.TestCase):
         assert payload.meta.timestamp == new_payload.meta.timestamp
         assert payload.meta.session_id == new_payload.meta.session_id
         assert payload.event_name == new_payload.event_name
-        assert payload.context.bot_slug == new_payload.context.bot_slug
-        assert payload.context.channel == new_payload.context.channel
-        assert payload.context.channel_user_id == new_payload.context.channel_user_id
+        assert payload.content['name'] == new_payload.content['name']
+        assert payload.content['text'] == new_payload.content['text']
+        assert payload.context['channel'] == new_payload.context['channel']
+        assert payload.context['channel_user']['name'] == new_payload.context['channel_user']['name']
+        assert payload.context['channel_user']['id'] == new_payload.context['channel_user']['id']
 
     def test_event_class(self):
         mock_envelope = mock.MagicMock()
@@ -100,5 +140,5 @@ class PayloadTest(unittest.TestCase):
             envelope=mock.MagicMock(),
             name='get_booking')
 
-        with pytest.raises(KeyError):
+        with pytest.raises(pydantic.ValidationError):
             helpers.aio_run(event.payload())


### PR DESCRIPTION
- Extract `Context` from the old `EventPayload`.
  - `Context` should have information required for all messages such as `tenant`, `bot_slug`, `channel`, and `channel_user_id`.
- Use `event_name` to validate the `content` and [pydantic](https://pydantic-docs.helpmanual.io/) annotations to validate the attributes of the `content`.

