### PR TITLE
Refactor/configuration etc

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,28 +1,22 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [packages]
-
 aioamqp = "*"
 "e1839a8" = {path = ".", editable = true}
 jsonschema = "*"
 pydantic = "*"
 pyyaml = "*"
-
+requests = "*"
 
 [dev-packages]
-
 pytest = "*"
 isort = "*"
 pylint = "*"
 "flake8" = "*"
 pytest-cov = "*"
 
-
 [requires]
-
 python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ aioamqp = "*"
 jsonschema = "*"
 pydantic = "*"
 pyyaml = "*"
-requests = "*"
 
 [dev-packages]
 pytest = "*"
@@ -17,6 +16,7 @@ isort = "*"
 pylint = "*"
 "flake8" = "*"
 pytest-cov = "*"
+requests = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "94b960b71efaf34b97ecfc27686b3f9172af6690e6a8440de035d750dcf1409c"
+            "sha256": "f3ea858b6f53a2ec92384d985c9c5fa3a65fa4b163f0f23a28d9b41e2faa2091"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -38,11 +38,11 @@
         },
         "pydantic": {
             "hashes": [
-                "sha256:3976cf6c1022a622136ccc5f3fa3a8bf174bd4539c8b085d2b66fc2272f60110",
-                "sha256:85639faeced3fb2ba9d149efbdf0a4c62630ac7b268af966c3d2dfc98235e86f"
+                "sha256:4bf085140abe47e9f92cdf46edf79a49fbc2660e35c329f1db907da07c33393c",
+                "sha256:de214c2994c460d8815c4b604ac1bfac3ce4d13e7b80afa566876405863d0d40"
             ],
             "index": "pypi",
-            "version": "==0.8"
+            "version": "==0.9"
         },
         "pyyaml": {
             "hashes": [
@@ -79,6 +79,20 @@
                 "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
             ],
             "version": "==17.4.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+            ],
+            "version": "==2018.4.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
         },
         "coverage": {
             "hashes": [
@@ -128,6 +142,13 @@
             ],
             "index": "pypi",
             "version": "==3.5.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+            ],
+            "version": "==2.6"
         },
         "isort": {
             "hashes": [
@@ -242,12 +263,27 @@
             "index": "pypi",
             "version": "==2.5.1"
         },
+        "requests": {
+            "hashes": [
+                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
+                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+            ],
+            "index": "pypi",
+            "version": "==2.18.4"
+        },
         "six": {
             "hashes": [
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
+                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+            ],
+            "version": "==1.22"
         },
         "wrapt": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ work within the Twyla platform.
 - `cd` to the directory and run `pipenv install --dev`.
 - Make sure that all tests pass: `pytest`.
 
+## Configuration
+
+The configuration values are read from environment variables whose names should
+have the same prefix. This prefix should be passed to the `EventBus` class on
+initialization. If the prefix is `EVENT_BUS`, for example, the following values
+should be set in the environment:
+
+```
+EVENT_BUS_AMQP_HOST
+EVENT_BUS_AMQP_PORT
+EVENT_BUS_AMQP_USER
+EVENT_BUS_AMQP_PASS
+EVENT_BUS_AMQP_VHOST
+```
+
 ## RPC (not yet implemented)
 
 Remote procedure calls are used for synchronous communication between services

--- a/twyla/service/events.py
+++ b/twyla/service/events.py
@@ -4,11 +4,10 @@ from twyla.service import queues
 
 class EventBus:
 
-    def __init__(self, config_prefix, group, emits):
+    def __init__(self, config_prefix: str, group: str):
         self.config_prefix = config_prefix
         self.group = group
         self.queue_manager = queues.QueueManager(config_prefix, group)
-        self.emits = emits
 
 
     async def listen(self, event_name, callback):

--- a/twyla/service/message.py
+++ b/twyla/service/message.py
@@ -23,8 +23,7 @@ class Event:
         event body happens. It returns an EventPayload object. The schema for
         deserialization and validation is loaded from a central schema service.
         """
-        payload = EventPayload.from_json(self.body)
-        return payload
+        return EventPayload.from_json(self.body)
 
 
     async def ack(self):

--- a/twyla/service/message.py
+++ b/twyla/service/message.py
@@ -17,31 +17,28 @@ class Event:
         self.envelope = envelope
         self.name = name
 
-    async def payload(self):
+    def payload(self):
         """
         The payload method is where the deserialization and validation of the
         event body happens. It returns an EventPayload object. The schema for
         deserialization and validation is loaded from a central schema service.
         """
-
-        try:
-            payload = EventPayload.from_json(self.body)
-        except ValidationError:
-            await self.drop()
-            raise
-
+        payload = EventPayload.from_json(self.body)
         return payload
+
 
     async def ack(self):
         if self.channel is not None:
             await self.channel.basic_client_ack(
                 delivery_tag=self.envelope.delivery_tag)
 
+
     async def reject(self):
         if self.channel is not None:
             await self.channel.basic_reject(
                 delivery_tag=self.envelope.delivery_tag,
                 requeue=True)
+
 
     async def drop(self):
         if self.channel is not None:

--- a/twyla/service/queues.py
+++ b/twyla/service/queues.py
@@ -13,33 +13,11 @@ from twyla.service.message import Event
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-def load_config():
-    """
-    load_config is used to get RabbitMQ configuration from the environment.
-
-    Required variables:
-    Name                    | Example
-    -------------------------------------
-    TWYLA_RABBITMQ_HOST     | localhost
-    TWYLA_RABBITMQ_PORT     | 5672
-    TWYLA_RABBITMQ_USER     | guest
-    TWYLA_RABBITMQ_PASS     | guest
-    TWYLA_RABBITMQ_EXCHANGE | events
-    TWYLA_RABBITMQ_VHOST    | /
-    TWYLA_RABBITMQ_PREFIX   | xpi
-
-    Every service should use a unique prefix; it will be used to prefix the
-    queue names for the different events and allow multiple services to listen
-    to the same events while multiple instances of the same service will be
-    listening to the same queue.
-    """
-
-    return config.from_env('TWYLA_RABBITMQ_')
-
-
 class QueueManager:
-    def __init__(self):
-        self.config = load_config()
+
+    def __init__(self, configuration_prefix, event_group):
+        self.config = config.from_env(configuration_prefix)
+        self.event_group = event_group
         self.protocol = None
         self.channel = None
         self.loop = asyncio.get_event_loop()

--- a/twyla/service/queues.py
+++ b/twyla/service/queues.py
@@ -74,14 +74,14 @@ class QueueManager:
     # Binding queues is only relevant for listeners, publishing will be done to
     # the exchange.
     async def bind_queue(self, event_name):
-        domain, event = split_event_name(event_name)
-        queue_name = f'{domain}.{event}.{self.event_group}'
+        domain, event_type = split_event_name(event_name)
+        queue_name = f'{domain}.{event_type}.{self.event_group}'
         await self.declare_exchange(domain)
         await self.channel.queue_declare(queue_name, durable=True)
         await self.channel.queue_bind(
             exchange_name=domain,
             queue_name=queue_name,
-            routing_key=event)
+            routing_key=event_type)
         return queue_name
 
 

--- a/twyla/service/queues.py
+++ b/twyla/service/queues.py
@@ -14,8 +14,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 def split_event_name(event_name: str):
     assert "." in event_name, "Event names should be of format domain.event_name"
-    splat = event_name.split('.', 1)
-    return splat[0], splat[1]
+    return event_name.split('.', 1)
 
 
 

--- a/twyla/service/test/common.py
+++ b/twyla/service/test/common.py
@@ -13,7 +13,7 @@ _content_schema = json.dumps({
 })
 
 _content_schema_set = {
-    'an-event': _content_schema,
+    'a-domain.an-event': _content_schema,
     'another-event': 'another-event-content-schema'
 }
 

--- a/twyla/service/test/integration/common.py
+++ b/twyla/service/test/integration/common.py
@@ -46,8 +46,8 @@ class RabbitRest:
     def publish_message(self, exchange_name, routing_key, payload):
         url = urljoin(self.BASE, f'exchanges/%2f/{exchange_name}/publish')
         body = {"properties": {},
-                "routing_key": "my key",
-                "payload": "my body",
+                "routing_key": routing_key,
+                "payload": payload,
                 "payload_encoding": "string"}
         resp = requests.post(url, json=body, auth=self.RABBIT_AUTH)
         return resp.json()

--- a/twyla/service/test/integration/common.py
+++ b/twyla/service/test/integration/common.py
@@ -40,8 +40,12 @@ class RabbitRest:
     def get_messages(self, queue_name):
         url = urljoin(self.BASE, f'queues/%2f/{queue_name}/get')
         body = {'count': 10, "ackmode":"ack_requeue_false", 'encoding': 'auto'}
-        resp = requests.post(url, json=body, auth=self.RABBIT_AUTH)
-        return resp.json()
+        response = requests.post(url, json=body, auth=self.RABBIT_AUTH).json()
+        if 'error' in response:
+            # this happens with older versions of rabbitmq like on travis ci.
+            body = {'count': 10, "requeue": False, 'encoding': 'auto'}
+            response = requests.post(url, json=body, auth=self.RABBIT_AUTH).json()
+        return response
 
     def publish_message(self, exchange_name, routing_key, payload):
         url = urljoin(self.BASE, f'exchanges/%2f/{exchange_name}/publish')

--- a/twyla/service/test/integration/common.py
+++ b/twyla/service/test/integration/common.py
@@ -1,0 +1,53 @@
+from urllib.parse import urljoin
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+class RabbitRest:
+
+    BASE = 'http://localhost:15672/api/'
+    RABBIT_AUTH = HTTPBasicAuth('guest', 'guest')
+
+    def queues(self):
+        return requests.get(urljoin(self.BASE, 'queues/%2F'), auth=self.RABBIT_AUTH).json()
+
+    def exchanges(self):
+        return requests.get(urljoin(self.BASE, 'exchanges/%2F'), auth=self.RABBIT_AUTH).json()
+
+    def create_queue(self, queue_name, bind_to, routing_key):
+        body = {"auto_delete": True ,"durable": False}
+        resp = requests.put(urljoin(self.BASE, f'queues/%2F/{queue_name}'),
+                            auth=self.RABBIT_AUTH,
+                            json=body)
+        resp = requests.post(urljoin(self.BASE, f"/api/bindings/%2F/e/{bind_to}/q/{queue_name}"),
+                             auth=self.RABBIT_AUTH,
+                             json={'routing_key': routing_key})
+
+
+    def delete_queue(self, queue_name):
+        url = urljoin(self.BASE, f'queues/%2f/{queue_name}')
+        requests.delete(url, auth=self.RABBIT_AUTH)
+
+    def delete_exchange(self, exchange_name):
+        url = urljoin(self.BASE, f'exchanges/%2f/{exchange_name}')
+        requests.delete(url, auth=self.RABBIT_AUTH)
+
+    def queue_bindings(self, queue_name):
+        return requests.get(urljoin(self.BASE, f'queues/%2F/{queue_name}/bindings'),
+                            auth=self.RABBIT_AUTH).json()
+
+
+    def get_messages(self, queue_name):
+        url = urljoin(self.BASE, f'queues/%2f/{queue_name}/get')
+        body = {'count': 10, "ackmode":"ack_requeue_false", 'encoding': 'auto'}
+        resp = requests.post(url, json=body, auth=self.RABBIT_AUTH)
+        return resp.json()
+
+    def publish_message(self, exchange_name, routing_key, payload):
+        url = urljoin(self.BASE, f'exchanges/%2f/{exchange_name}/publish')
+        body = {"properties": {},
+                "routing_key": "my key",
+                "payload": "my body",
+                "payload_encoding": "string"}
+        resp = requests.post(url, json=body, auth=self.RABBIT_AUTH)
+        return resp.json()

--- a/twyla/service/test/integration/test_event_bus.py
+++ b/twyla/service/test/integration/test_event_bus.py
@@ -90,6 +90,7 @@ class TestQueues(unittest.TestCase):
 
         loop = asyncio.get_event_loop()
         loop.run_until_complete(doit())
+        assert len(received) == 1
         payload = json.loads(received[0])
         assert payload['content']['name'] == 'test-name-content'
 

--- a/twyla/service/test/integration/test_event_bus.py
+++ b/twyla/service/test/integration/test_event_bus.py
@@ -35,7 +35,7 @@ class TestQueues(unittest.TestCase):
 
     def test_emit(self):
         self.rabbit.create_queue("a-domain.an-event.testing", "a-domain", "an-event")
-        event_bus = EventBus('TWYLA_', 'testing', ['a-domain.an-event'])
+        event_bus = EventBus('TWYLA_', 'testing')
         event = EventPayload(
             event_name='a-domain.an-event',
             content={
@@ -78,7 +78,7 @@ class TestQueues(unittest.TestCase):
             }
         )
 
-        event_bus = EventBus('TWYLA_', 'testing', ['a-domain.to-be-listened'])
+        event_bus = EventBus('TWYLA_', 'testing')
         received = []
         async def consumer_callback(channel, body, envelope, properties):
             received.append(body)
@@ -112,7 +112,7 @@ class TestQueues(unittest.TestCase):
             await channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
 
         async def listen():
-            event_bus = EventBus('TWYLA_', 'testing', ['a-domain.to-be-listened'])
+            event_bus = EventBus('TWYLA_', 'testing')
             await event_bus.listen('a-domain.to-be-listened', consumer_callback)
 
         async def stopper():

--- a/twyla/service/test/integration/test_event_bus.py
+++ b/twyla/service/test/integration/test_event_bus.py
@@ -85,8 +85,11 @@ class TestQueues(unittest.TestCase):
             await channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
 
         async def doit():
+            # the first listen call is to create and bind the queue
             await event_bus.listen('a-domain.to-be-listened', consumer_callback)
             self.rabbit.publish_message('a-domain', 'to-be-listened', event_payload.to_json())
+            await event_bus.listen('a-domain.to-be-listened', consumer_callback)
+
 
         loop = asyncio.get_event_loop()
         loop.run_until_complete(doit())

--- a/twyla/service/test/integration/test_queue_manager.py
+++ b/twyla/service/test/integration/test_queue_manager.py
@@ -93,3 +93,14 @@ class TestQueues(unittest.TestCase):
         binding_to_exchange = [x for x in bindings if x['source'] == 'a-domain']
         assert len(binding_to_exchange) == 1
         assert binding_to_exchange[0]['routing_key'] == 'an-event'
+
+
+    def test_declare_exchange(self):
+        qm = queues.QueueManager('TWYLA_', 'the-group')
+        loop = asyncio.get_event_loop()
+        async def doit():
+            await qm.connect()
+            await qm.declare_exchange("emit-domain")
+        loop.run_until_complete(doit())
+        exchanges = self.rabbit.exchanges()
+        assert 'emit-domain' in [x['name'] for x in exchanges]

--- a/twyla/service/test/integration/test_queue_manager.py
+++ b/twyla/service/test/integration/test_queue_manager.py
@@ -4,47 +4,14 @@ import os
 import pytest
 import unittest
 import unittest.mock as mock
-from urllib.parse import urljoin
 
-import requests
-from requests.auth import HTTPBasicAuth
-
-import twyla.service.events as events
 import twyla.service.queues as queues
+
+from twyla.service.test.integration.common import RabbitRest
 
 
 def noop(*args, **kwargs):
     pass
-
-class RabbitRest:
-
-    BASE = 'http://localhost:15672/api/'
-    RABBIT_AUTH = HTTPBasicAuth('guest', 'guest')
-
-    def queues(self):
-        return requests.get(urljoin(self.BASE, 'queues/%2F'), auth=self.RABBIT_AUTH).json()
-
-    def exchanges(self):
-        return requests.get(urljoin(self.BASE, 'exchanges/%2F'), auth=self.RABBIT_AUTH).json()
-
-    def delete_queue(self, queue_name):
-        url = urljoin(self.BASE, f'queues/%2f/{queue_name}')
-        requests.delete(url, auth=self.RABBIT_AUTH)
-
-    def delete_exchange(self, exchange_name):
-        url = urljoin(self.BASE, f'exchanges/%2f/{exchange_name}')
-        requests.delete(url, auth=self.RABBIT_AUTH)
-
-    def queue_bindings(self, queue_name):
-        return requests.get(urljoin(self.BASE, f'queues/%2F/{queue_name}/bindings'),
-                            auth=self.RABBIT_AUTH).json()
-
-
-    def get_messages(self, queue_name):
-        url = urljoin(self.BASE, f'queues/%2f/{queue_name}/get')
-        body = {'count': 10, "ackmode":"ack_requeue_true", 'encoding': 'auto'}
-        resp = requests.post(url, json=body, auth=self.RABBIT_AUTH)
-        return resp.json()
 
 
 class TestQueues(unittest.TestCase):

--- a/twyla/service/test/integration/test_queue_manager.py
+++ b/twyla/service/test/integration/test_queue_manager.py
@@ -1,0 +1,35 @@
+import asyncio
+from concurrent.futures._base import CancelledError
+import os
+import pytest
+import unittest
+import unittest.mock as mock
+
+import twyla.service.events as events
+import twyla.service.queues as queues
+
+class TestQueues(unittest.TestCase):
+
+    def setUp(self):
+        self.event_name = 'test-event'
+        self.patcher = mock.patch.dict(
+            os.environ,
+            {'TWYLA_AMQP_HOST': 'localhost',
+             'TWYLA_AMQP_PORT': '5672',
+             'TWYLA_AMQP_USER': 'guest',
+             'TWYLA_AMQP_PASS': 'guest',
+             'TWYLA_AMQP_VHOST': '/'})
+        self.patcher.start()
+
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_load_configuration_with_prefix(self):
+        qm = queues.QueueManager('TWYLA_', 'the-group')
+        assert qm.config['amqp_host'] == 'localhost'
+        assert qm.config['amqp_port'] == '5672'
+        assert qm.config['amqp_user'] == 'guest'
+        assert qm.config['amqp_pass'] == 'guest'
+        assert qm.config['amqp_vhost'] == '/'
+        assert qm.event_group == 'the-group'

--- a/twyla/service/test/integration/test_queue_manager.py
+++ b/twyla/service/test/integration/test_queue_manager.py
@@ -13,6 +13,9 @@ import twyla.service.events as events
 import twyla.service.queues as queues
 
 
+def noop(*args, **kwargs):
+    pass
+
 class RabbitRest:
 
     BASE = 'http://localhost:15672/api/'
@@ -47,7 +50,6 @@ class RabbitRest:
 class TestQueues(unittest.TestCase):
 
     def setUp(self):
-        self.event_name = 'test-event'
         self.patcher = mock.patch.dict(
             os.environ,
             {'TWYLA_AMQP_HOST': 'localhost',
@@ -76,7 +78,7 @@ class TestQueues(unittest.TestCase):
         qm = queues.QueueManager('TWYLA_', 'the-group')
         loop = asyncio.get_event_loop()
         with pytest.raises(AssertionError):
-            loop.run_until_complete(qm.listen('an-event'))
+            loop.run_until_complete(qm.listen('an-event', noop))
 
 
     def test_declare_queues_and_exchanges_for_listener(self):
@@ -84,7 +86,7 @@ class TestQueues(unittest.TestCase):
         loop = asyncio.get_event_loop()
         async def doit():
             await qm.connect()
-            await qm.listen('a-domain.an-event')
+            await qm.listen('a-domain.an-event', noop)
         loop.run_until_complete(doit())
         rabbit_queues = self.rabbit.queues()
         assert 'a-domain.an-event.the-group' in [x['name'] for x in rabbit_queues]

--- a/twyla/service/test/integration/test_queue_manager.py
+++ b/twyla/service/test/integration/test_queue_manager.py
@@ -4,9 +4,45 @@ import os
 import pytest
 import unittest
 import unittest.mock as mock
+from urllib.parse import urljoin
+
+import requests
+from requests.auth import HTTPBasicAuth
 
 import twyla.service.events as events
 import twyla.service.queues as queues
+
+
+class RabbitRest:
+
+    BASE = 'http://localhost:15672/api/'
+    RABBIT_AUTH = HTTPBasicAuth('guest', 'guest')
+
+    def queues(self):
+        return requests.get(urljoin(self.BASE, 'queues/%2F'), auth=self.RABBIT_AUTH).json()
+
+    def exchanges(self):
+        return requests.get(urljoin(self.BASE, 'exchanges/%2F'), auth=self.RABBIT_AUTH).json()
+
+    def delete_queue(self, queue_name):
+        url = urljoin(self.BASE, f'queues/%2f/{queue_name}')
+        requests.delete(url, auth=self.RABBIT_AUTH)
+
+    def delete_exchange(self, exchange_name):
+        url = urljoin(self.BASE, f'exchanges/%2f/{exchange_name}')
+        requests.delete(url, auth=self.RABBIT_AUTH)
+
+    def queue_bindings(self, queue_name):
+        return requests.get(urljoin(self.BASE, f'queues/%2F/{queue_name}/bindings'),
+                            auth=self.RABBIT_AUTH).json()
+
+
+    def get_messages(self, queue_name):
+        url = urljoin(self.BASE, f'queues/%2f/{queue_name}/get')
+        body = {'count': 10, "ackmode":"ack_requeue_true", 'encoding': 'auto'}
+        resp = requests.post(url, json=body, auth=self.RABBIT_AUTH)
+        return resp.json()
+
 
 class TestQueues(unittest.TestCase):
 
@@ -20,6 +56,7 @@ class TestQueues(unittest.TestCase):
              'TWYLA_AMQP_PASS': 'guest',
              'TWYLA_AMQP_VHOST': '/'})
         self.patcher.start()
+        self.rabbit = RabbitRest()
 
 
     def tearDown(self):
@@ -33,3 +70,26 @@ class TestQueues(unittest.TestCase):
         assert qm.config['amqp_pass'] == 'guest'
         assert qm.config['amqp_vhost'] == '/'
         assert qm.event_group == 'the-group'
+
+
+    def test_raise_exception_on_invalid_event_name(self):
+        qm = queues.QueueManager('TWYLA_', 'the-group')
+        loop = asyncio.get_event_loop()
+        with pytest.raises(AssertionError):
+            loop.run_until_complete(qm.listen('an-event'))
+
+
+    def test_declare_queues_and_exchanges_for_listener(self):
+        qm = queues.QueueManager('TWYLA_', 'the-group')
+        loop = asyncio.get_event_loop()
+        async def doit():
+            await qm.connect()
+            await qm.listen('a-domain.an-event')
+        loop.run_until_complete(doit())
+        rabbit_queues = self.rabbit.queues()
+        assert 'a-domain.an-event.the-group' in [x['name'] for x in rabbit_queues]
+        bindings = self.rabbit.queue_bindings('a-domain.an-event.the-group')
+        assert len(bindings) == 2
+        binding_to_exchange = [x for x in bindings if x['source'] == 'a-domain']
+        assert len(binding_to_exchange) == 1
+        assert binding_to_exchange[0]['routing_key'] == 'an-event'

--- a/twyla/service/test/unit/test_events.py
+++ b/twyla/service/test/unit/test_events.py
@@ -23,7 +23,7 @@ class EventsTests(unittest.TestCase):
         qm = QueueMock()
         mock_queues.QueueManager.return_value = qm
 
-        event_bus = events.EventBus('TWYLA_', 'testing', ['a-domain.an-event'])
+        event_bus = events.EventBus('TWYLA_', 'testing')
 
         async def callback(*args, **kwargs):
             pass

--- a/twyla/service/test/unit/test_message.py
+++ b/twyla/service/test/unit/test_message.py
@@ -1,5 +1,7 @@
+import json
 import unittest
 import unittest.mock as mock
+from types import SimpleNamespace as Bunch
 
 import pydantic
 import pytest
@@ -8,78 +10,97 @@ import twyla.service.message as message
 import twyla.service.test.helpers as helpers
 import twyla.service.test.common as common
 
+EVENT_PAYLOAD = json.dumps(
+    {"event_name": "a-domain.an-event",
+     "content": {
+         "name": "test-name",
+         "text": "test-text"},
+     "context": {
+         "channel": "test-channel",
+         "channel_user": {
+             "name": "test-user",
+             "id": 24
+         }}
+    })
+
+INVALID_PAYLOAD = json.dumps(
+    {"message_type": "integration-request",
+     "bot_slug": "slow-slug",
+     "content": {},
+     "channel": "fbmessenger",
+     "channel_user_id": "some-user-id"
+    })
+
+
+class MockChannel:
+
+    def __init__(self):
+        self.acked = []
+        self.rejected = []
+        self.dropoped = []
+
+    async def basic_client_ack(self, delivery_tag):
+        self.acked.append(delivery_tag)
+
+    async def basic_reject(self, delivery_tag, requeue):
+        self.rejected.append((delivery_tag, requeue))
+
 
 class PayloadTest(unittest.TestCase):
+
     def setUp(self):
         self.content_schema_set, self.context_schema  = common.schemata_fixtures()
-
-        self.test_body = '''
-        {
-            "event_name": "an-event",
-            "content": {
-                "name": "test-name",
-                "text": "test-text"
-            },
-            "context": {
-                "channel": "test-channel",
-                "channel_user": {
-                    "name": "test-user",
-                    "id": 24
-                }
-            }
-        }
-        '''
-
-        self.invalid_test_body = '''
-        {
-            "message_type": "integration-request",
-            "bot_slug": "slow-slug",
-            "content": {},
-            "channel": "fbmessenger",
-            "channel_user_id": "some-user-id"
-        }
-        '''
-
         message._CONTENT_SCHEMA_SET = None
         message._CONTEXT_SCHEMA = None
 
+
+    def tearDown(self):
+        message._CONTENT_SCHEMA_SET = None
+        message._CONTEXT_SCHEMA = None
+
+
     def test_validation_with_no_schemata_set(self):
         with pytest.raises(Exception):
-            payload = message.EventPayload.from_json(self.test_body)
+            payload = message.EventPayload.from_json(EVENT_PAYLOAD)
+
 
     def test_validation_with_only_content(self):
         message.set_schemata(self.content_schema_set, None)
         with pytest.raises(Exception):
-            payload = message.EventPayload.from_json(self.test_body)
+            payload = message.EventPayload.from_json(EVENT_PAYLOAD)
+
 
     def test_set_schemata_with_incorrect_content_schemata_set(self):
         with pytest.raises(AssertionError):
-            message.set_schemata(self.invalid_test_body, self.context_schema)
-    
+            message.set_schemata(INVALID_PAYLOAD, self.context_schema)
+
+
     def test_set_schemata_happy_path(self):
         message.set_schemata(self.content_schema_set, self.context_schema)
         content_schema_set, context_schema = message.get_schemata()
         assert content_schema_set == self.content_schema_set
         assert context_schema == self.context_schema
 
+
     def test_payload_from_json(self):
         message.set_schemata(self.content_schema_set, self.context_schema)
-        payload = message.EventPayload.from_json(self.test_body)
+        payload = message.EventPayload.from_json(EVENT_PAYLOAD)
 
         assert isinstance(payload.meta, message.Meta)
         assert isinstance(payload.content, dict)
         assert isinstance(payload.context, dict)
 
-        assert payload.event_name == 'an-event'
+        assert payload.event_name == 'a-domain.an-event'
         assert payload.content['name'] == 'test-name'
         assert payload.content['text'] == 'test-text'
         assert payload.context['channel'] == 'test-channel'
         assert payload.context['channel_user']['name'] == 'test-user'
         assert payload.context['channel_user']['id'] == 24
 
+
     def test_payload_serialization_roundtrip(self):
         message.set_schemata(self.content_schema_set, self.context_schema)
-        payload = message.EventPayload.from_json(self.test_body)
+        payload = message.EventPayload.from_json(EVENT_PAYLOAD)
         raw_json = payload.to_json()
 
         new_payload = message.EventPayload.from_json(raw_json)
@@ -93,44 +114,67 @@ class PayloadTest(unittest.TestCase):
         assert payload.context['channel_user']['name'] == new_payload.context['channel_user']['name']
         assert payload.context['channel_user']['id'] == new_payload.context['channel_user']['id']
 
-    def test_event_class(self):
-        message.set_schemata(self.content_schema_set, self.context_schema)
-        mock_envelope = mock.MagicMock()
-        mock_envelope.delivery_tag = 1
-        mock_channel = helpers.AsyncMock()
+
+class EventTests(unittest.TestCase):
+
+    def setUp(self):
+        content_schema_set, context_schema  = common.schemata_fixtures()
+        message.set_schemata(content_schema_set, context_schema)
+
+    def tearDown(self):
+        message._CONTENT_SCHEMA_SET = None
+        message._CONTEXT_SCHEMA = None
+
+    def test_ack_event(self):
+        envelope = Bunch(delivery_tag=12345)
+        mock_channel = MockChannel()
         event = message.Event(
             channel=mock_channel,
-            body=self.test_body,
-            envelope=mock_envelope,
+            body=EVENT_PAYLOAD,
+            envelope=envelope,
             name='get_booking')
 
-        payload = helpers.aio_run(event.payload())
+        payload = event.payload()
 
         assert isinstance(payload, message.EventPayload)
 
         helpers.aio_run(event.ack())
-        event.channel.basic_client_ack.assert_called_once_with(
-            mock_channel,
-            delivery_tag=1)
+        assert len(mock_channel.acked) == 1
+        assert mock_channel.acked[0] == 12345
+
+
+    def test_reject_event(self):
+        envelope = Bunch(delivery_tag=12345)
+        mock_channel = MockChannel()
+        event = message.Event(
+            channel=mock_channel,
+            body=EVENT_PAYLOAD,
+            envelope=envelope,
+            name='get_booking')
 
         helpers.aio_run(event.reject())
-        event.channel.basic_reject.assert_called_with(
-            mock_channel,
-            delivery_tag=1,
-            requeue=True)
+        assert len(mock_channel.rejected) == 1
+        assert mock_channel.rejected[0] == (12345, True)
+
+
+    def test_drop_event(self):
+        envelope = Bunch(delivery_tag=12345)
+        mock_channel = MockChannel()
+        event = message.Event(
+            channel=mock_channel,
+            body=EVENT_PAYLOAD,
+            envelope=envelope,
+            name='get_booking')
 
         helpers.aio_run(event.drop())
-        event.channel.basic_reject.assert_called_with(
-            mock_channel,
-            delivery_tag=1,
-            requeue=False)
+        assert len(mock_channel.rejected) == 1
+        assert mock_channel.rejected[0] == (12345, False)
 
-        assert event.channel.basic_reject.call_count == 2
 
     def test_event_class_bad_body(self):
         event = message.Event(
             channel=helpers.AsyncMock(),
-            body=self.invalid_test_body,
+            body=INVALID_PAYLOAD,
             envelope=mock.MagicMock(),
             name='get_booking')
 

--- a/twyla/service/test/unit/test_queues.py
+++ b/twyla/service/test/unit/test_queues.py
@@ -3,6 +3,7 @@ import os
 import unittest
 import unittest.mock as mock
 
+import pytest
 from aioamqp.protocol import OPEN
 
 import twyla.service.queues as queues
@@ -80,6 +81,13 @@ class QueueManagerTests(unittest.TestCase):
 
     def tearDown(self):
         self.patcher.stop()
+
+    def test_split_event_name(self):
+        domain, event_name = queues.split_event_name('the-domain.the-event-name')
+        assert domain == 'the-domain'
+        assert event_name == 'the-event-name'
+        with pytest.raises(AssertionError):
+            queues.split_event_name('not a proper name')
 
 
     @mock.patch('twyla.service.queues.aioamqp', new_callable=MockAioamqp)


### PR DESCRIPTION
This PR changes the interface of the event listener to be callback-based instead of async iteration, which would enable listening to multiple messages. Also fixed and cleaned up various things. Still needs to be done for prod use: 
- Separate adding callback and declaring listening from actually listening to events. 
- Add main loop that runs a service.
- Add tests for various things such as listening to multiple events, better unit tests.